### PR TITLE
Trivial fix for array indexing going past the end

### DIFF
--- a/kstars/auxiliary/ksutils.cpp
+++ b/kstars/auxiliary/ksutils.cpp
@@ -164,7 +164,7 @@ QString toDirectionString( dms angle )
 
     int index = (int)( (angle.reduce().Degrees() + 11.25) / 22.5); // A number between 0 and 16 (inclusive) is expected
     if( index < 0 || index > 16 )
-        index = 17; // Something went wrong.
+        index = 16; // Something went wrong.
     else
         index = ( ( index == 16 ) ? 0 : index );
 


### PR DESCRIPTION
Managed to somehow trigger the error condition when loading "What's Interesting" window and that caused segmentation fault on line 171 when the array was indexed past the end. There are 17 items in the array so the last index is 16 and not 17.