### PR TITLE
Fix typo: If Guiding Deviation > XX arcsec

### DIFF
--- a/kstars/ekos/capture/capture.ui
+++ b/kstars/ekos/capture/capture.ui
@@ -1105,7 +1105,7 @@
            <string>Abort sequence if guiding deviation exceed this value</string>
           </property>
           <property name="text">
-           <string>Guiding Deviation &lt;</string>
+           <string>Guiding Deviation &gt;</string>
           </property>
           <property name="checked">
            <bool>false</bool>


### PR DESCRIPTION
The sequence is aborted when guiding deviation '>' XX arcsec
and not '<' XX arcsec.