### PR TITLE
QSX build fails unless QApplication is included.

### DIFF
--- a/kstars/indi/guimanager.cpp
+++ b/kstars/indi/guimanager.cpp
@@ -19,6 +19,7 @@
 #include <KActionCollection>
 #include <KMessageBox>
 
+#include <QApplication>
 #include <QSplitter>
 #include <QTextEdit>
 #include <QPushButton>


### PR DESCRIPTION
OSX build fails with the following if QApplication is not included.

error: incomplete type 'QApplication' named in nested name
      specifier
        connect(QApplication::instance(), SIGNAL(applicationStateChanged(Qt::ApplicationState)), this,
                ^~~~~~~~~~~~~~
/usr/local/opt/qt/lib/QtGui.framework/Headers/qwindowdefs.h:81:7: note: forward declaration of 'QApplication'