### PR TITLE
Enable high DPI support

### DIFF
--- a/kstars/main.cpp
+++ b/kstars/main.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
                           main.cpp  -  K Desktop Planetarium
                              -------------------
     begin                : Mon Feb  5 01:11:45 PST 2001
@@ -62,9 +62,7 @@ Q_DECL_EXPORT
 #endif
 int main(int argc, char *argv[])
 {
-#ifdef KSTARS_LITE
     QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-#endif
     QApplication app(argc, argv);
 
 #ifdef Q_OS_OSX


### PR DESCRIPTION
This was originally disabled because the version of Qt that KStars was using was older than the version of Qt that KStars Lite was using, and didn't have High DPI support.  KStars is now using a much more recent version of Qt, and has full High DPI support.  So let's use it!

This makes things look much better on my 4K monitor. Previously some things would scale, and some things wouldn't, making things look a little weird. Now everything scales properly.
