### PR TITLE
calculating cumulative frequency corrected

### DIFF
--- a/kstars/fitsviewer/fitshistogram.cpp
+++ b/kstars/fitsviewer/fitshistogram.cpp
@@ -187,9 +187,13 @@ void FITSHistogram::constructHistogram()
     }
 
     // Cumulative Frequency
-    for (int i = 0; i < binCount; i++)
-        for (int j = 0; j <= i; j++)
-            cumulativeFrequency[i] += r_frequency[j];
+    int j = 0;
+    double val = 0;
+    for (int i = 0; i < binCount; i++) {
+        val += r_frequency[j++];
+        cumulativeFrequency.replace(i, val);
+    }
+
 
     if (image_data->getNumOfChannels() == 1)
     {


### PR DESCRIPTION
The current implementation of the cumulative frequency is implemented very inefficient. I changed it making its runtime linear.

Additionally, I changed the method for changing an element inside a QVector. At least on my raspberry, this seems to have side effects and changed the "channels" attribute leading to a crash.