### PR TITLE
made Meridian Flip Time Out a configurable value

### DIFF
--- a/kstars/ekos/capture/capture.cpp
+++ b/kstars/ekos/capture/capture.cpp
@@ -32,7 +32,6 @@
 
 #include <ekos_capture_debug.h>
 
-#define MF_TIMER_TIMEOUT    90000
 #define GD_TIMER_TIMEOUT    60000
 #define MF_RA_DIFF_LIMIT    4
 
@@ -4311,7 +4310,7 @@ bool Capture::checkMeridianFlip()
             m_State = CAPTURE_MERIDIAN_FLIP;
             emit newStatus(Ekos::CAPTURE_MERIDIAN_FLIP);
 
-            QTimer::singleShot(MF_TIMER_TIMEOUT, this, &Ekos::Capture::checkMeridianFlipTimeout);
+            QTimer::singleShot(meridianTimeOut->value()*1000, this, &Ekos::Capture::checkMeridianFlipTimeout);
             return true;
         }
     }

--- a/kstars/ekos/capture/capture.ui
+++ b/kstars/ekos/capture/capture.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>625</width>
-    <height>547</height>
+    <width>702</width>
+    <height>758</height>
    </rect>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,2">
@@ -1105,19 +1105,6 @@ font-weight:bold;
         <property name="spacing">
          <number>1</number>
         </property>
-        <item row="1" column="3">
-         <widget class="QLabel" name="textLabel1_2_5">
-          <property name="toolTip">
-           <string>Number of images to capture</string>
-          </property>
-          <property name="whatsThis">
-           <string/>
-          </property>
-          <property name="text">
-           <string>pixels</string>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="3">
          <widget class="QLabel" name="textLabel1_2_6">
           <property name="toolTip">
@@ -1128,6 +1115,19 @@ font-weight:bold;
           </property>
           <property name="text">
            <string>hours</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="3">
+         <widget class="QLabel" name="textLabel1_2_5">
+          <property name="toolTip">
+           <string>Number of images to capture</string>
+          </property>
+          <property name="whatsThis">
+           <string/>
+          </property>
+          <property name="text">
+           <string>pixels</string>
           </property>
          </widget>
         </item>
@@ -1279,7 +1279,7 @@ font-weight:bold;
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -1291,6 +1291,36 @@ font-weight:bold;
            </size>
           </property>
          </spacer>
+        </item>
+        <item row="4" column="1">
+         <widget class="QDoubleSpinBox" name="meridianTimeOut">
+          <property name="decimals">
+           <number>0</number>
+          </property>
+          <property name="maximum">
+           <double>600.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>10.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>90.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="meridiantimeout_label">
+          <property name="text">
+           <string>Meridian Flip Time Out</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="3">
+         <widget class="QLabel" name="meridianTimeOutUnits_Label">
+          <property name="text">
+           <string>Seconds</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -1732,7 +1762,8 @@ font-weight:bold;
             <string/>
            </property>
            <property name="icon">
-            <iconset theme="camera-off"/>
+            <iconset theme="camera-off">
+             <normaloff>.</normaloff>.</iconset>
            </property>
            <property name="iconSize">
             <size>


### PR DESCRIPTION
Dear Jasem,

I made a change in Ekos Capture so that Meridian Flip Time Out can be set from the UI since default value of 90 seconds was not enough. I kept the default at 90.
![ekos](https://user-images.githubusercontent.com/20877647/52059092-2e4b6e80-2569-11e9-8b25-01a5083cf80a.jpg)
