### PR TITLE
Update opsastrometry.ui

### DIFF
--- a/kstars/ekos/align/opsastrometry.ui
+++ b/kstars/ekos/align/opsastrometry.ui
@@ -84,28 +84,6 @@
           </property>
          </widget>
         </item>
-        <item>
-         <widget class="QCheckBox" name="checkBox_30">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Overwrite already generated files. It must be checked to prevent solver failure.</string>
-          </property>
-          <property name="text">
-           <string>-O</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-         </widget>
-        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
Ok, this is all new to me so please forgive me if what I am doing is utter rubbish. In [https://indilib.org/forum/ekos/5095-solver-oddities.html#38318] we agreed to remove the -O option in Solver Options. In the code I found something that did look like it, removed it, recompiled and fully expected the whole thing to crash on me. But it didn't. The -O option was gone. I have no idea if this indeed is all it takes. Anyway, in my irrational exuberance I proceed to a pull request.