### PR TITLE
Update phd2.cpp

### DIFF
--- a/kstars/ekos/guide/externalguide/phd2.cpp
+++ b/kstars/ekos/guide/externalguide/phd2.cpp
@@ -284,8 +284,9 @@ void PHD2::processPHD2Event(const QJsonObject &jsonEvent, const QByteArray &line
         case StartGuiding:
             setEquipmentConnected();
             updateGuideParameters();
-            emit newLog(i18n("PHD2: Guiding Started."));
-            emit newStatus(Ekos::GUIDE_GUIDING);
+            // Do not report guiding as started as it will start scheduled capture before SettleDone
+            // just print the log message
+            emit newLog(i18n("PHD2: Waiting for guiding to settle."));
             break;
 
         case Paused:


### PR DESCRIPTION
Do not report guiding as started in PHD2::StartGuiding Event handler because it will start scheduled capture prematurely (before Settle is complete).

---------------------------------------------------
I was shooting a large mosaic (64 panels) with 135mm lens guiding with PHD2 and Ekos and there was a problem where guiding would be reported as started before GuideSettle, resulting in lost guide star and other issues. I traced it down to StartGuiding event handler incorrectly emitting newStatus(GUIDE_GUIDING) which would immediately trigger the capture in scheduler. PHD2 will always send SettleDone and GUIDE_GUIDING should be set there to avoid that problem. I tested the change extensively using simulators and did not find any issues - all works as expected.

---------------------------------------------------
Alex Cherney
Ekos 3.3.5 on RPi 3B+ with Ubuntu Mate 16.04