### PR TITLE
Add breeze to dep command line

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -28,7 +28,7 @@ required and optional.
 
 KStars requires 16.04+. Install the prerequisites:
 
-sudo apt-get -y install build-essential cmake git pkg-config libeigen3-dev libcfitsio-dev zlib1g-dev libindi-dev extra-cmake-modules libkf5plotting-dev libqt5svg5-dev libkf5xmlgui-dev kio-dev kinit-dev libkf5newstuff-dev kdoctools-dev libkf5notifications-dev qtdeclarative5-dev libkf5crash-dev gettext libnova-dev libgsl-dev libraw-dev libkf5notifyconfig-dev wcslib-dev libqt5websockets5-dev xplanet xplanet-images qt5keychain-dev libsecret-1-dev
+sudo apt-get -y install build-essential cmake git pkg-config libeigen3-dev libcfitsio-dev zlib1g-dev libindi-dev extra-cmake-modules libkf5plotting-dev libqt5svg5-dev libkf5xmlgui-dev kio-dev kinit-dev libkf5newstuff-dev kdoctools-dev libkf5notifications-dev qtdeclarative5-dev libkf5crash-dev gettext libnova-dev libgsl-dev libraw-dev libkf5notifyconfig-dev wcslib-dev libqt5websockets5-dev xplanet xplanet-images qt5keychain-dev libsecret-1-dev breeze
 
 2.2 Other Systems
 


### PR DESCRIPTION
Reference bug report 411735
Adding "breeze" icon set to the ubuntu dependency command line should ensure the icons are right in Kstars after building.