### PR TITLE
Update gmath.cpp

### DIFF
--- a/kstars/ekos/guide/internalguide/gmath.cpp
+++ b/kstars/ekos/guide/internalguide/gmath.cpp
@@ -1204,7 +1204,7 @@ void cgmath::process_axes(void)
     in_params.proportional_gain[1] = Options::dECProportionalGain();
 
     in_params.integral_gain[0] = Options::rAIntegralGain();
-    in_params.integral_gain[1] = Options::rAIntegralGain();
+    in_params.integral_gain[1] = Options::dECIntegralGain();
 
     in_params.derivative_gain[0] = Options::rADerivativeGain();
     in_params.derivative_gain[1] = Options::dECDerivativeGain();


### PR DESCRIPTION
Looked like it was a duplicated.  Original had the following: 
in_params.integral_gain[0] = Options::rAIntegralGain();
    in_params.integral_gain[1] = Options::rAIntegralGain();

Hope that helps.