### PR TITLE
Fix for temperature delta check

### DIFF
--- a/kstars/ekos/capture/capture.cpp
+++ b/kstars/ekos/capture/capture.cpp
@@ -1920,6 +1920,9 @@ IPState Capture::resumeSequence()
 
         if (next_job)
         {
+            //check delta also when starting a new job!
+            isTemperatureDeltaCheckActive = (m_AutoFocusReady && limitFocusDeltaTS->isChecked());
+            
             prepareJob(next_job);
 
             //Resume guiding if it was suspended before


### PR DESCRIPTION
When using single exposure jobs (SHOSHO...) the focus delta check never becomes enabled