### PR TITLE
childrenCollapsable disabled in manager.ui to avoid collapsing the log 

### DIFF
--- a/kstars/ekos/manager.ui
+++ b/kstars/ekos/manager.ui
@@ -70,6 +70,9 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
      <widget class="QTabWidget" name="toolsWidget">
       <property name="sizePolicy">
        <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -1071,12 +1074,6 @@
    <class>CaptureCountsWidget</class>
    <extends>QWidget</extends>
    <header>ekos/capture/capturecountswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>QProgressIndicator</class>
-   <extends>QWidget</extends>
-   <header>auxiliary/QProgressIndicator.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
Small bugfix:

when childrenCollapsable is enabled for the splitter widget the user is unable to change the size of the controls in the manager. Always the log window and the options button is collapsed entirely and the user is not able to get it back - kstars needs to be restarted. 

I just disabled childrenCollapsable, so the splitter can now be moved to change the vertical size of the log window. However, now it never collapses entirely and the user can always use the option button for changes. 
