### PR TITLE
Mount model wizard improvements

### DIFF
--- a/Tests/ekos/align/CMakeLists.txt
+++ b/Tests/ekos/align/CMakeLists.txt
@@ -1,3 +1,8 @@
+ADD_EXECUTABLE( test_mountmodel_halton test_mountmodel_halton.cpp )
+TARGET_LINK_LIBRARIES( test_mountmodel_halton ${TEST_LIBRARIES})
+ADD_TEST( NAME TestMountModelHalton COMMAND test_mountmodel_halton )
+SET_TESTS_PROPERTIES( TestMountModelHalton PROPERTIES LABELS "stable")
+
 ADD_EXECUTABLE( test_poleaxis test_poleaxis.cpp )
 TARGET_LINK_LIBRARIES( test_poleaxis ${TEST_LIBRARIES})
 ADD_TEST( NAME TestPoleAxis COMMAND test_poleaxis )

--- a/Tests/ekos/align/test_mountmodel_halton.cpp
+++ b/Tests/ekos/align/test_mountmodel_halton.cpp
@@ -1,0 +1,168 @@
+/*
+    SPDX-FileCopyrightText: 2026 Christian Kemper <ckemper@gmail.com>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#include "test_mountmodel_halton.h"
+#include "auxiliary/dms.h"
+#include "skyobjects/skypoint.h"
+
+#include <cmath>
+#include <QtTest>
+
+// Number of Halton points to generate per test case.
+static constexpr int kNumPoints = 50;
+
+// Matches the constants in mountmodel.cpp.
+static constexpr double kMaxAlt    = 85.0;
+static constexpr double kMaxAbsDec = 80.0;
+
+TestMountModelHalton::TestMountModelHalton() : QObject() {}
+
+// Replicate the halton() member from MountModel (3-line pure function).
+double TestMountModelHalton::halton(int index, int base)
+{
+    double result = 0.0;
+    double f      = 1.0;
+    while (index > 0)
+    {
+        f /= static_cast<double>(base);
+        result += (index % base) * f;
+        index /= base;
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// testPointsAboveHorizon
+//
+// For each (lat, LST, minAlt) combination, generate kNumPoints via the same
+// AltAz-space Halton logic used in MountModel::slotWizardAlignmentPoints(),
+// then convert the stored (ra, dec) back to AltAz and verify alt >= minAlt.
+// ---------------------------------------------------------------------------
+
+void TestMountModelHalton::testPointsAboveHorizon_data()
+{
+    QTest::addColumn<double>("lat");
+    QTest::addColumn<double>("lst");   // hours
+    QTest::addColumn<double>("minAlt");
+
+    // Mid-northern latitudes
+    QTest::newRow("lat=34 lst=0  minAlt=10") << 34.0 << 0.0  << 10.0;
+    QTest::newRow("lat=34 lst=6  minAlt=20") << 34.0 << 6.0  << 20.0;
+    QTest::newRow("lat=34 lst=12 minAlt=30") << 34.0 << 12.0 << 30.0;
+    QTest::newRow("lat=34 lst=18 minAlt=30") << 34.0 << 18.0 << 30.0;
+
+    // Mid-southern latitudes
+    QTest::newRow("lat=-34 lst=0  minAlt=20") << -34.0 << 0.0  << 20.0;
+    QTest::newRow("lat=-34 lst=12 minAlt=30") << -34.0 << 12.0 << 30.0;
+
+    // Near-equatorial
+    QTest::newRow("lat=0 lst=6 minAlt=20")  << 0.0  << 6.0  << 20.0;
+    QTest::newRow("lat=5 lst=12 minAlt=20") << 5.0  << 12.0 << 20.0;
+
+    // High northern latitude (NCP nearly overhead)
+    QTest::newRow("lat=60 lst=0  minAlt=10") << 60.0 << 0.0  << 10.0;
+    QTest::newRow("lat=60 lst=12 minAlt=20") << 60.0 << 12.0 << 20.0;
+
+    // High southern latitude
+    QTest::newRow("lat=-60 lst=6 minAlt=10") << -60.0 << 6.0 << 10.0;
+}
+
+void TestMountModelHalton::testPointsAboveHorizon()
+{
+    QFETCH(double, lat);
+    QFETCH(double, lst);
+    QFETCH(double, minAlt);
+
+    dms latDms(lat);
+    dms lstDms;
+    lstDms.setH(lst);
+
+    double sinMin = std::sin(minAlt   * dms::DegToRad);
+    double sinMax = std::sin(kMaxAlt  * dms::DegToRad);
+
+    for (int i = 1; i <= kNumPoints; i++)
+    {
+        double az  = halton(i, 2) * 360.0;
+        double alt = std::asin(sinMin + halton(i, 3) * (sinMax - sinMin)) / dms::DegToRad;
+
+        // Convert AltAz -> equatorial (same as the implementation).
+        SkyPoint sp;
+        sp.setAlt(alt);
+        sp.setAz(az);
+        sp.HorizontalToEquatorial(&lstDms, &latDms);
+
+        double ra  = sp.ra().Hours();
+        double dec = std::copysign(qMin(std::abs(sp.dec().Degrees()), kMaxAbsDec),
+                                   sp.dec().Degrees());
+
+        // Convert (ra, dec) back to AltAz to verify the point is above the horizon.
+        SkyPoint check;
+        check.setRA(ra);
+        check.setDec(dec);
+        check.EquatorialToHorizontal(&lstDms, &latDms);
+
+        double checkAlt = check.alt().Degrees();
+        QVERIFY2(checkAlt >= minAlt - 0.001,
+                 qPrintable(QString("Point %1: az=%2 alt=%3 -> ra=%4 dec=%5 -> checkAlt=%6 < minAlt=%7")
+                            .arg(i).arg(az, 0, 'f', 2).arg(alt, 0, 'f', 2)
+                            .arg(ra, 0, 'f', 4).arg(dec, 0, 'f', 4)
+                            .arg(checkAlt, 0, 'f', 4).arg(minAlt)));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// testPointsAwayFromPole
+//
+// Verify that after Dec clamping, |Dec| <= kMaxAbsDec for all points and
+// all observer locations.
+// ---------------------------------------------------------------------------
+
+void TestMountModelHalton::testPointsAwayFromPole_data()
+{
+    QTest::addColumn<double>("lat");
+    QTest::addColumn<double>("lst");
+    QTest::addColumn<double>("minAlt");
+
+    QTest::newRow("lat=34  lst=0  minAlt=30") << 34.0  << 0.0  << 30.0;
+    QTest::newRow("lat=-34 lst=12 minAlt=30") << -34.0 << 12.0 << 30.0;
+    QTest::newRow("lat=60  lst=6  minAlt=10") << 60.0  << 6.0  << 10.0;
+    QTest::newRow("lat=-60 lst=18 minAlt=10") << -60.0 << 18.0 << 10.0;
+    QTest::newRow("lat=0   lst=0  minAlt=20") << 0.0   << 0.0  << 20.0;
+}
+
+void TestMountModelHalton::testPointsAwayFromPole()
+{
+    QFETCH(double, lat);
+    QFETCH(double, lst);
+    QFETCH(double, minAlt);
+
+    dms latDms(lat);
+    dms lstDms;
+    lstDms.setH(lst);
+
+    double sinMin = std::sin(minAlt  * dms::DegToRad);
+    double sinMax = std::sin(kMaxAlt * dms::DegToRad);
+
+    for (int i = 1; i <= kNumPoints; i++)
+    {
+        double az  = halton(i, 2) * 360.0;
+        double alt = std::asin(sinMin + halton(i, 3) * (sinMax - sinMin)) / dms::DegToRad;
+
+        SkyPoint sp;
+        sp.setAlt(alt);
+        sp.setAz(az);
+        sp.HorizontalToEquatorial(&lstDms, &latDms);
+
+        double dec = std::copysign(qMin(std::abs(sp.dec().Degrees()), kMaxAbsDec),
+                                   sp.dec().Degrees());
+
+        QVERIFY2(std::abs(dec) <= kMaxAbsDec + 0.001,
+                 qPrintable(QString("Point %1: |dec|=%2 exceeds kMaxAbsDec=%3")
+                            .arg(i).arg(std::abs(dec), 0, 'f', 4).arg(kMaxAbsDec)));
+    }
+}
+
+QTEST_GUILESS_MAIN(TestMountModelHalton)

--- a/Tests/ekos/align/test_mountmodel_halton.h
+++ b/Tests/ekos/align/test_mountmodel_halton.h
@@ -1,0 +1,36 @@
+/*
+    SPDX-FileCopyrightText: 2026 Christian Kemper <ckemper@gmail.com>
+
+    SPDX-License-Identifier: GPL-2.0-or-later
+*/
+
+#ifndef TEST_MOUNTMODEL_HALTON_H
+#define TEST_MOUNTMODEL_HALTON_H
+
+#include <QtGlobal>
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+#include <QtTest/QTest>
+#else
+#include <QTest>
+#endif
+
+class TestMountModelHalton : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestMountModelHalton();
+    ~TestMountModelHalton() override = default;
+
+private Q_SLOTS:
+    void testPointsAboveHorizon_data();
+    void testPointsAboveHorizon();
+
+    void testPointsAwayFromPole_data();
+    void testPointsAwayFromPole();
+
+private:
+    static double halton(int index, int base);
+};
+
+#endif

--- a/kstars/ekos/align/mountmodel.cpp
+++ b/kstars/ekos/align/mountmodel.cpp
@@ -436,91 +436,81 @@ bool MountModel::saveAlignmentPoints(const QString &path)
     return true;
 }
 
+void MountModel::swapAlignPoints(int firstPt, int secondPt)
+{
+    for (int i = 0; i < alignTable->columnCount(); i++)
+    {
+        QTableWidgetItem *firstPtItem  = alignTable->takeItem(firstPt, i);
+        QTableWidgetItem *secondPtItem = alignTable->takeItem(secondPt, i);
+        alignTable->setItem(firstPt, i, secondPtItem);
+        alignTable->setItem(secondPt, i, firstPtItem);
+    }
+}
+
+void MountModel::sortTableRows(int fromRow, const SkyPoint &start)
+{
+    int rowCount = alignTable->rowCount();
+    if (fromRow >= rowCount)
+        return;
+
+    auto skyPointAt = [&](int row) -> SkyPoint
+    {
+        return SkyPoint(dms::fromString(alignTable->item(row, 0)->text(), false),
+                        dms::fromString(alignTable->item(row, 1)->text(), true));
+    };
+
+    // Find the row in [fromRow, rowCount) closest to start and swap it to fromRow.
+    SkyPoint ref = start;
+    dms bestDiff(360);
+    int bestIndex = fromRow;
+    for (int i = fromRow; i < rowCount; i++)
+    {
+        if (!alignTable->item(i, 0) || !alignTable->item(i, 1))
+            continue;
+        SkyPoint sp = skyPointAt(i);
+        dms diff = ref.angularDistanceTo(&sp);
+        if (diff.Degrees() < bestDiff.Degrees())
+        {
+            bestIndex = i;
+            bestDiff  = diff;
+        }
+    }
+    if (bestIndex != fromRow)
+        swapAlignPoints(bestIndex, fromRow);
+
+    // Nearest-neighbour for the rest of the range.
+    for (int i = fromRow; i < rowCount - 1; i++)
+    {
+        if (!alignTable->item(i, 0) || !alignTable->item(i, 1))
+            continue;
+        SkyPoint current = skyPointAt(i);
+        bestDiff  = dms(360);
+        bestIndex = i + 1;
+        for (int j = i + 1; j < rowCount; j++)
+        {
+            if (!alignTable->item(j, 0) || !alignTable->item(j, 1))
+                continue;
+            SkyPoint sp = skyPointAt(j);
+            dms diff = current.angularDistanceTo(&sp);
+            if (diff.Degrees() < bestDiff.Degrees())
+            {
+                bestIndex = j;
+                bestDiff  = diff;
+            }
+        }
+        if (bestIndex != i + 1)
+            swapAlignPoints(bestIndex, i + 1);
+    }
+}
+
 void MountModel::slotSortAlignmentPoints()
 {
-    int firstAlignmentPt = findClosestAlignmentPointToTelescope();
-    if (firstAlignmentPt != -1)
-    {
-        swapAlignPoints(firstAlignmentPt, 0);
-    }
-
-    for (int i = 0; i < alignTable->rowCount() - 1; i++)
-    {
-        int nextAlignmentPoint = findNextAlignmentPointAfter(i);
-        if (nextAlignmentPoint != -1)
-        {
-            swapAlignPoints(nextAlignmentPoint, i + 1);
-        }
-    }
+    // While a run is in progress, sort only the points not yet visited so that
+    // completed rows are not disturbed and currentAlignmentPoint stays valid.
+    int fromRow = m_IsRunning ? currentAlignmentPoint : 0;
+    sortTableRows(fromRow, telescopeCoord);
     if (previewShowing)
         updatePreviewAlignPoints();
-}
-
-int MountModel::findClosestAlignmentPointToTelescope()
-{
-    dms bestDiff = dms(360);
-    double index = -1;
-
-    for (int i = 0; i < alignTable->rowCount(); i++)
-    {
-        QTableWidgetItem *raCell = alignTable->item(i, 0);
-        QTableWidgetItem *deCell = alignTable->item(i, 1);
-
-        if (raCell && deCell)
-        {
-            dms raDMS = dms::fromString(raCell->text(), false);
-            dms deDMS = dms::fromString(deCell->text(), true);
-
-            SkyPoint sk(raDMS, deDMS);
-            dms thisDiff = telescopeCoord.angularDistanceTo(&sk);
-            if (thisDiff.Degrees() < bestDiff.Degrees())
-            {
-                index    = i;
-                bestDiff = thisDiff;
-            }
-        }
-    }
-    return index;
-}
-
-int MountModel::findNextAlignmentPointAfter(int currentSpot)
-{
-    QTableWidgetItem *currentRACell = alignTable->item(currentSpot, 0);
-    QTableWidgetItem *currentDECell = alignTable->item(currentSpot, 1);
-
-    if (currentRACell && currentDECell)
-    {
-        dms thisRADMS = dms::fromString(currentRACell->text(), false);
-        dms thisDEDMS = dms::fromString(currentDECell->text(), true);
-
-        SkyPoint thisPt(thisRADMS, thisDEDMS);
-
-        dms bestDiff = dms(360);
-        double index = -1;
-
-        for (int i = currentSpot + 1; i < alignTable->rowCount(); i++)
-        {
-            QTableWidgetItem *raCell = alignTable->item(i, 0);
-            QTableWidgetItem *deCell = alignTable->item(i, 1);
-
-            if (raCell && deCell)
-            {
-                dms raDMS = dms::fromString(raCell->text(), false);
-                dms deDMS = dms::fromString(deCell->text(), true);
-                SkyPoint point(raDMS, deDMS);
-                dms thisDiff = thisPt.angularDistanceTo(&point);
-
-                if (thisDiff.Degrees() < bestDiff.Degrees())
-                {
-                    index    = i;
-                    bestDiff = thisDiff;
-                }
-            }
-        }
-        return index;
-    }
-    else
-        return -1;
 }
 
 void MountModel::slotWizardAlignmentPoints()
@@ -1022,17 +1012,6 @@ void MountModel::moveAlignPoint(int logicalIndex, int oldVisualIndex, int newVis
         updatePreviewAlignPoints();
 }
 
-void MountModel::swapAlignPoints(int firstPt, int secondPt)
-{
-    for (int i = 0; i < alignTable->columnCount(); i++)
-    {
-        QTableWidgetItem *firstPtItem  = alignTable->takeItem(firstPt, i);
-        QTableWidgetItem *secondPtItem = alignTable->takeItem(secondPt, i);
-
-        alignTable->setItem(firstPt, i, secondPtItem);
-        alignTable->setItem(secondPt, i, firstPtItem);
-    }
-}
 
 void MountModel::slotAddAlignPoint()
 {

--- a/kstars/ekos/align/mountmodel.cpp
+++ b/kstars/ekos/align/mountmodel.cpp
@@ -7,6 +7,7 @@
 #include "mountmodel.h"
 
 #include "align.h"
+#include "Options.h"
 #include "kstars.h"
 #include "kstarsdata.h"
 #include "flagcomponent.h"
@@ -119,7 +120,8 @@ MountModel::MountModel(Align *parent) : QDialog(parent)
 
 MountModel::~MountModel()
 {
-
+    if (m_solverSettingsSaved)
+        restoreSolverSettings();
 }
 
 void MountModel::generateAlignStarList()
@@ -964,6 +966,8 @@ void MountModel::resetAlignmentProcedure()
     statusReport->setIcon(QIcon(":/icons/AlignWarning.svg"));
     alignTable->setItem(currentAlignmentPoint, 3, statusReport);
 
+    if (m_solverSettingsSaved)
+        restoreSolverSettings();
     Q_EMIT newLog(i18n("The Mount Model Tool is Reset."));
     startAlignB->setIcon(
         QIcon::fromTheme("media-playback-start"));
@@ -1028,6 +1032,7 @@ void MountModel::startStopAlignmentProcedure()
             startAlignB->setIcon(
                 QIcon::fromTheme("media-playback-pause"));
             m_IsRunning = true;
+            saveAndOverrideSolverSettings();
             Q_EMIT newLog(i18n("The Mount Model Tool is Starting."));
             startAlignmentPoint();
         }
@@ -1040,6 +1045,7 @@ void MountModel::startStopAlignmentProcedure()
         Q_EMIT newLog(i18n("The Mount Model Tool is Paused."));
         Q_EMIT aborted();
         m_IsRunning = false;
+        restoreSolverSettings();
 
         QTableWidgetItem *statusReport = new QTableWidgetItem();
         statusReport->setFlags(Qt::ItemIsSelectable);
@@ -1067,7 +1073,10 @@ void MountModel::startAlignmentPoint()
         alignIndicator->startAnimation();
 
         const SkyObject *target = getWizardAlignObject(raDeg, dec);
-        m_AlignInstance->setTarget(*target);
+        if (target)
+            m_AlignInstance->setTarget(*target);
+        else
+            m_AlignInstance->setTarget(SkyPoint(raDMS, decDMS));
         m_AlignInstance->Slew();
     }
 }
@@ -1094,12 +1103,40 @@ void MountModel::finishAlignmentPoint(bool solverSucceeded)
         else
         {
             m_IsRunning = false;
+            restoreSolverSettings();
             startAlignB->setIcon(
                 QIcon::fromTheme("media-playback-start"));
             Q_EMIT newLog(i18n("The Mount Model Tool is Finished."));
             currentAlignmentPoint = 0;
         }
     }
+}
+
+void MountModel::saveAndOverrideSolverSettings()
+{
+    m_savedUsePosition = Options::astrometryUsePosition();
+    m_savedUseScale    = Options::astrometryUseImageScale();
+    m_savedGotoMode    = static_cast<int>(m_AlignInstance->currentGOTOMode());
+    m_solverSettingsSaved = true;
+
+    Options::setAstrometryUsePosition(false);
+    Options::setAstrometryUseImageScale(false);
+
+    // Only override the goto mode if it is not already GOTO_NOTHING (report-only run)
+    if (m_AlignInstance->currentGOTOMode() != Align::GOTO_NOTHING)
+        m_AlignInstance->setSolverAction(Align::GOTO_SYNC);
+
+    emit newLog(i18n("Mount model: forcing blind solve and sync for each alignment point."));
+}
+
+void MountModel::restoreSolverSettings()
+{
+    if (!m_solverSettingsSaved)
+        return;
+    Options::setAstrometryUsePosition(m_savedUsePosition);
+    Options::setAstrometryUseImageScale(m_savedUseScale);
+    m_AlignInstance->setSolverAction(static_cast<int>(m_savedGotoMode));
+    m_solverSettingsSaved = false;
 }
 
 void MountModel::setAlignStatus(Ekos::AlignState state)

--- a/kstars/ekos/align/mountmodel.cpp
+++ b/kstars/ekos/align/mountmodel.cpp
@@ -557,6 +557,118 @@ void MountModel::slotWizardAlignmentPoints()
         }
     }
 
+    if (alignTypeBox->currentIndex() == OBJECT_HALTON_SEQUENCE ||
+        alignTypeBox->currentIndex() == OBJECT_NAMED_STAR ||
+        alignTypeBox->currentIndex() == OBJECT_ANY_STAR ||
+        alignTypeBox->currentIndex() == OBJECT_ANY_OBJECT)
+    {
+        // Generate points directly in AltAz space so every point is above the
+        // horizon by construction.  85 deg ceiling avoids the azimuth singularity
+        // near zenith.  Points whose declination exceeds +-80 deg after conversion
+        // are discarded (not clamped) so the stored (ra, dec) always corresponds
+        // to the generated AltAz position.
+        constexpr double maxAlt    = 85.0;
+        constexpr double maxAbsDec = 80.0;
+        double sinMin = std::sin(minAlt * dms::DegToRad);
+        double sinMax = std::sin(maxAlt * dms::DegToRad);
+
+        const bool snap = alignTypeBox->currentIndex() != OBJECT_HALTON_SEQUENCE;
+        QSet<const SkyObject *> usedObjects;
+        struct Point { QString ra, dec, name; };
+        QVector<Point> newPoints;
+
+        // Iterate through the Halton sequence until we have enough points.
+        // Use a generous upper bound to handle sparse catalogues at high latitudes.
+        const int maxCandidates = qMax(points * 10, 200);
+        for (int i = 1; i <= maxCandidates && newPoints.size() < points; i++)
+        {
+            double az  = halton(i, 2) * 360.0;
+            double alt = std::asin(sinMin + halton(i, 3) * (sinMax - sinMin)) / dms::DegToRad;
+
+            SkyPoint sp;
+            sp.setAlt(alt);
+            sp.setAz(az);
+            sp.HorizontalToEquatorial(data->lst(), data->geo()->lat());
+
+            double ra  = sp.ra().Hours();
+            double dec = sp.dec().Degrees();
+            if (std::abs(dec) > maxAbsDec)
+                continue;
+
+            QString ra_report, dec_report, name;
+
+            if (snap)
+            {
+                const SkyObject *obj = getWizardAlignObject(ra * 15.0, dec);
+                if (!obj)
+                    continue;
+                if (usedObjects.contains(obj))
+                    continue;
+                usedObjects.insert(obj);
+                SkyObject *o = obj->clone();
+                o->updateCoords(data->updateNum(), true, data->geo()->lat(), data->lst(), false);
+                getFormattedCoords(o->ra0().Hours(), o->dec0().Degrees(), ra_report, dec_report);
+                name = o->longname();
+                delete o;
+            }
+            else
+            {
+                getFormattedCoords(ra, dec, ra_report, dec_report);
+                name = i18n("Sky Point");
+            }
+
+            newPoints.append({ra_report, dec_report, name});
+        }
+
+        if (newPoints.size() < points)
+            Q_EMIT newLog(i18n("Warning: only %1 of %2 requested alignment points could be placed.",
+                               newPoints.size(), points));
+
+        // Determine start point for sorting: last existing row, or telescope if table is empty.
+        SkyPoint sortStart = telescopeCoord;
+        int lastExistingRow = alignTable->rowCount() - 1;
+        if (lastExistingRow >= 0)
+        {
+            QTableWidgetItem *raCell  = alignTable->item(lastExistingRow, 0);
+            QTableWidgetItem *decCell = alignTable->item(lastExistingRow, 1);
+            if (raCell && decCell)
+                sortStart = SkyPoint(dms::fromString(raCell->text(), false),
+                                     dms::fromString(decCell->text(), true));
+        }
+        const int firstNewRow = alignTable->rowCount();
+
+        for (const auto &pt : newPoints)
+        {
+            int currentRow = alignTable->rowCount();
+            alignTable->insertRow(currentRow);
+
+            QTableWidgetItem *RAReport = new QTableWidgetItem();
+            RAReport->setText(pt.ra);
+            RAReport->setTextAlignment(Qt::AlignHCenter);
+            alignTable->setItem(currentRow, 0, RAReport);
+
+            QTableWidgetItem *DECReport = new QTableWidgetItem();
+            DECReport->setText(pt.dec);
+            DECReport->setTextAlignment(Qt::AlignHCenter);
+            alignTable->setItem(currentRow, 1, DECReport);
+
+            QTableWidgetItem *ObjNameReport = new QTableWidgetItem();
+            ObjNameReport->setText(pt.name);
+            ObjNameReport->setTextAlignment(Qt::AlignHCenter);
+            alignTable->setItem(currentRow, 2, ObjNameReport);
+
+            QTableWidgetItem *disabledBox = new QTableWidgetItem();
+            disabledBox->setFlags(Qt::ItemIsSelectable);
+            alignTable->setItem(currentRow, 3, disabledBox);
+        }
+
+        sortTableRows(firstNewRow, sortStart);
+
+        if (previewShowing)
+            updatePreviewAlignPoints();
+        return;
+    }
+
     //If there are less than 6 points, keep them all in the same DEC,
     //any more, set the num per row to be the sqrt of the points to evenly distribute in RA and DEC
     int numRAperDEC = 5;
@@ -739,6 +851,20 @@ void MountModel::calculateAZPointsForDEC(dms dec, dms alt, dms &AZEast, dms &AZW
     AZWest.setRadians(2.0 * dms::PI - AZRad);
 }
 
+double MountModel::halton(int index, int base)
+{
+    double result = 0;
+    double f      = 1.0 / base;
+    int i         = index;
+    while (i > 0)
+    {
+        result += f * (i % base);
+        i /= base;
+        f /= base;
+    }
+    return result;
+}
+
 const SkyObject *MountModel::getWizardAlignObject(double ra, double dec)
 {
     double maxSearch = 5.0;
@@ -748,6 +874,7 @@ const SkyObject *MountModel::getWizardAlignObject(double ra, double dec)
             return KStarsData::Instance()->skyComposite()->objectNearest(new SkyPoint(dms(ra), dms(dec)), maxSearch);
         case OBJECT_FIXED_DEC:
         case OBJECT_FIXED_GRID:
+        case OBJECT_HALTON_SEQUENCE:
             return nullptr;
 
         case OBJECT_ANY_STAR:
@@ -1059,11 +1186,14 @@ void MountModel::startAlignmentPoint()
     if (m_IsRunning && currentAlignmentPoint >= 0 && currentAlignmentPoint < alignTable->rowCount())
     {
         QTableWidgetItem *raCell = alignTable->item(currentAlignmentPoint, 0);
+        QTableWidgetItem *decCell = alignTable->item(currentAlignmentPoint, 1);
+        if (!raCell || !decCell)
+            return;
+
         QString raString         = raCell->text();
         dms raDMS                = dms::fromString(raString, false);
         double raDeg             = raDMS.Degrees();
 
-        QTableWidgetItem *decCell = alignTable->item(currentAlignmentPoint, 1);
         QString decString         = decCell->text();
         dms decDMS                = dms::fromString(decString, true);
         double dec                = decDMS.Degrees();

--- a/kstars/ekos/align/mountmodel.h
+++ b/kstars/ekos/align/mountmodel.h
@@ -36,6 +36,7 @@ class MountModel : public QDialog, public Ui::mountModel
             OBJECT_ANY_STAR,
             OBJECT_NAMED_STAR,
             OBJECT_ANY_OBJECT,
+            OBJECT_HALTON_SEQUENCE,
             OBJECT_FIXED_DEC,
             OBJECT_FIXED_GRID
         };
@@ -88,6 +89,7 @@ class MountModel : public QDialog, public Ui::mountModel
         int findNextAlignmentPointAfter(int currentSpot);
         int findClosestAlignmentPointToTelescope();
         void swapAlignPoints(int firstPt, int secondPt);
+        double halton(int index, int base);
 
         void saveAndOverrideSolverSettings();
         void restoreSolverSettings();

--- a/kstars/ekos/align/mountmodel.h
+++ b/kstars/ekos/align/mountmodel.h
@@ -86,8 +86,7 @@ class MountModel : public QDialog, public Ui::mountModel
                                      double minAlt);
         void calculateAZPointsForDEC(dms dec, dms alt, dms &AZEast, dms &AZWest);
         void updatePreviewAlignPoints();
-        int findNextAlignmentPointAfter(int currentSpot);
-        int findClosestAlignmentPointToTelescope();
+        void sortTableRows(int fromRow, const SkyPoint &start);
         void swapAlignPoints(int firstPt, int secondPt);
         double halton(int index, int base);
 

--- a/kstars/ekos/align/mountmodel.h
+++ b/kstars/ekos/align/mountmodel.h
@@ -89,6 +89,9 @@ class MountModel : public QDialog, public Ui::mountModel
         int findClosestAlignmentPointToTelescope();
         void swapAlignPoints(int firstPt, int secondPt);
 
+        void saveAndOverrideSolverSettings();
+        void restoreSolverSettings();
+
         /**
              * @brief Get formatted RA & DEC coordinates compatible with astrometry.net format.
              * @param ra Right ascension
@@ -111,6 +114,12 @@ class MountModel : public QDialog, public Ui::mountModel
         QVector<const StarObject *> alignStars;
         QUrl alignURL;
         SkyPoint telescopeCoord;
+
+        // Saved solver settings restored after model run
+        bool m_solverSettingsSaved { false };
+        bool m_savedUsePosition { false };
+        bool m_savedUseScale { false };
+        int m_savedGotoMode { 2 };  // Align::GOTO_NOTHING -- safe no-op default
 
 
 };

--- a/kstars/ekos/align/mountmodel.ui
+++ b/kstars/ekos/align/mountmodel.ui
@@ -58,13 +58,15 @@
       <item row="2" column="1" colspan="4">
        <widget class="QComboBox" name="alignTypeBox">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select the type of objects/points added by the wizard.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Note:&lt;/span&gt; all of the options except Fixed DEC start with a grid of RA/DEC points.&lt;/p&gt;
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select how the wizard chooses alignment points.&lt;/p&gt;
+&lt;p&gt;All modes except Fixed DEC and Fixed Grid spread points evenly across the sky using uniform distribution. The modes differ in what each point snaps to:&lt;/p&gt;
 &lt;ul&gt;
-&lt;li&gt;&lt;b&gt;Any Stars:&lt;/b&gt; The wizard searches for the nearest star.&lt;/li&gt;
-&lt;li&gt;&lt;b&gt;Any object:&lt;/b&gt;  The wizard searches for the nearest object of any type.&lt;/li&gt;
-&lt;li&gt;&lt;b&gt;Named Stars&lt;/b&gt; The wizard searches for the nearest star in the currently visible star list. Note that the first named star might be fairly far from the intended point and also sometimes the same star could be the closest one for multiple points.&lt;/li&gt;
-&lt;li&gt;&lt;b&gt;Fixed DEC:&lt;/b&gt; The wizard generates all points at the chosen DEC.&lt;/li&gt;
-&lt;li&gt;&lt;b&gt;Fixed Grid:&lt;/b&gt;  The wizard just uses the original grid without trying to pair it with objects.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Any Stars:&lt;/b&gt; Snaps to the nearest visible star.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Named Stars:&lt;/b&gt; Snaps to a well-known named star (e.g. Vega, Arcturus).&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Any Object:&lt;/b&gt; Snaps to the nearest visible object of any type.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Uniform Distribution:&lt;/b&gt; Points are spread evenly across the visible sky.&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Fixed DEC:&lt;/b&gt; All points share the same declination (set below).&lt;/li&gt;
+&lt;li&gt;&lt;b&gt;Fixed Grid:&lt;/b&gt; Points arranged in a regular RA/DEC grid, evenly spaced in RA and DEC.&lt;/li&gt;
 &lt;/ul&gt;
 &lt;/body&gt;&lt;/html&gt;</string>
         </property>
@@ -81,6 +83,11 @@
         <item>
          <property name="text">
           <string>Any Object</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Uniform Distribution</string>
          </property>
         </item>
         <item>


### PR DESCRIPTION
## Automatic blind solve and sync

The wizard now automatically configures the solver for each alignment point. Blind solves
are used because no pointing model exists yet at the start of a run, so the mount's
reported position may be significantly off -- position or scale hints would cause solves
to fail. The GOTO mode is forced to Sync so the mount is updated after each successful
solve. The original settings are saved and restored when the run finishes, is aborted,
or is reset -- including if the dialog is closed mid-run.

## Uniform Distribution mode

A new "Uniform Distribution" alignment type generates points spread evenly across the
visible sky. A Halton sequence (https://en.wikipedia.org/wiki/Halton_sequence, bases 2
and 3) is used internally, sampling in AltAz space to guarantee every point is above the
configured minimum altitude. Points whose declination exceeds +/-80 deg after conversion
are rejected. A warning is logged if fewer points than requested could be placed
(e.g. sparse catalogue coverage at high latitudes).

The Any Stars, Named Stars, and Any Object modes also adopt this distribution internally
and snap each generated position to the nearest qualifying object. The Fixed Grid mode
is unchanged.

## Auto-sorted wizard output

Points added by the wizard are automatically sorted in nearest-neighbour slew order,
minimising total slew distance. Users no longer need to click Sort after running the
wizard. Clicking Sort during a run reorders only the remaining unvisited points, leaving
completed rows undisturbed.